### PR TITLE
remove cte from pid calculations

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -50,7 +50,7 @@ class Controller(object):
         #correct_steering = self.steering_pid.step(cross_track_err, dura_secs)
         #steering = predict_steering + correct_steering
 
-        return throttle, brake, predict_steering
+        return throttle, brake, filtered_steering
 
 
     def reset(self):

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,7 +1,7 @@
 import math
 from pid import PID
 from yaw_controller import YawController
-
+from lowpass import LowPassFilter
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
 
@@ -24,32 +24,35 @@ class Controller(object):
         self.linear_pid = PID(kp = 0.8, ki = 0, kd = 0.05, mn = self.decel_limit, mx = 0.5 * self.accel_limit)
         self.yaw_controller = YawController(self.wheel_base, self.steer_ratio, min_speed, self.max_lat_accel, self.max_steer_angle)
         self.steering_pid = PID(kp = 0.15, ki = 0.001, kd = 0.1, mn = -self.max_steer_angle, mx = self.max_steer_angle)
-    
-    
+        self.filter = LowPassFilter(0.2, 0.1)
+
+
     #def control(self, *args, **kwargs):
     def control(self, targ_lin_vel, targ_ang_vel, curr_lin_vel, cross_track_err, dura_secs):
         # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
         #return 1., 0., 0.
         lin_vel_err = targ_lin_vel - curr_lin_vel
-        
+
         vel_correct = self.linear_pid.step(lin_vel_err, dura_secs)
-        
+
         brake = 0
         throttle = vel_correct
-        
+
         if(throttle < 0):
             deceleration = abs(throttle)
             brake = (self.vehicle_mass + self.fuel_capacity * GAS_DENSITY) * self.wheel_radius * deceleration if deceleration > self.brake_deadband else 0.
             throttle = 0
-        
-        predict_steering = self.yaw_controller.get_steering(targ_lin_vel, targ_ang_vel, curr_lin_vel)
-        correct_steering = self.steering_pid.step(cross_track_err, dura_secs)
-        steering = predict_steering + correct_steering
-        
-        return throttle, brake, steering
-    
-    
+
+        predict_steering = self.yaw_controller.get_steering(targ_lin_vel, targ_ang_vel,
+                                                            curr_lin_vel)
+        filtered_steering = self.filter.filt(predict_steering)
+        #correct_steering = self.steering_pid.step(cross_track_err, dura_secs)
+        #steering = predict_steering + correct_steering
+
+        return throttle, brake, predict_steering
+
+
     def reset(self):
         self.linear_pid.reset()
         self.steering_pid.reset()


### PR DESCRIPTION
if we want to optimize better for latency, we have do make it in the waypoint_follower node.
the already provided target linear and angular velocities are enough